### PR TITLE
fix: the npm template of organization cannot download

### DIFF
--- a/src/utils/format-repository.js
+++ b/src/utils/format-repository.js
@@ -51,14 +51,14 @@ module.exports = link => {
     }
 
     throwError('Template path cannot be found. Ensure it is an exist directory.')
-  } else if (githubSH.test(link)) {
-    if (!/^github:/.test(link)) log.warn(`Don't use '${link}' anymore. And use 'github:${link}' instead.`)
-    return formatRepository(`https://github.com/${link.replace(/^github:/, '')}.git`)
   } else if (gitUrlRegexp.test(link)) {
     return formatRepository(link)
   } else if (/^npm:/.test(link) && validateNpmPackageName(link.substring('npm:'.length))) {
     // npm:xxxx/xxx
     return { type: 'npm', url: link, owner: '', name: link.substring('npm:'.length), path: link }
+  } else if (githubSH.test(link)) {
+    if (!/^github:/.test(link)) log.warn(`Don't use '${link}' anymore. And use 'github:${link}' instead.`)
+    return formatRepository(`https://github.com/${link.replace(/^github:/, '')}.git`)
   }
 
   throwError(`Invalid repository url: ${link}`)


### PR DESCRIPTION


<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first -->
<!-- Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request. -->


**Close issues**
resolve #73

**Additional context**
The name of organizational package was matched as shorthand url of github.


**Please check if the PR fulfills these requirements**

- [x] Have you followed the guidelines in our [Contributing document](https://github.com/Val-istar-Guo/mili/blob/master/.github/CODE_OF_CONDUCT.md)?
- [x] Have you written new tests for your core changes, as applicable?
